### PR TITLE
Feature/auto complete adhoc query

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,9 @@ type App struct {
 	editorSchemaSplit *container.Split
 	rightSplit        *container.Split
 
+	contextTimer   *time.Timer
+	contextTimerMu sync.Mutex
+
 	ctx       context.Context
 	cancelRun context.CancelFunc
 }
@@ -157,6 +160,11 @@ func (a *App) wireCallbacks() {
 	// Editor: project data needed for autocomplete → load datasets+tables
 	a.editor.SetOnProjectNeeded(func(project string) {
 		a.loadProjectDataForAutocomplete(project)
+	})
+
+	// Editor: text changed → debounced context-aware autocomplete update
+	a.editor.SetOnTextChanged(func(sql string) {
+		a.scheduleContextUpdate(sql)
 	})
 
 	// Explorer: table selected -> show schema + generate SELECT query
@@ -291,6 +299,9 @@ func (a *App) wireCallbacks() {
 }
 
 func (a *App) runQuery(project, sqlText string) {
+	// Cancel any pending schema fetches so they don't compete with the query.
+	a.cancelPendingContextUpdate()
+
 	if a.cancelRun != nil {
 		a.cancelRun()
 	}
@@ -302,27 +313,40 @@ func (a *App) runQuery(project, sqlText string) {
 	fyne.Do(func() { a.rightSplit.SetOffset(0.4) })
 	start := time.Now()
 
-	result, err := a.bqMgr.RunQuery(ctx, project, sqlText)
+	// Stream results: columns appear immediately, then rows arrive incrementally.
+	result, err := a.bqMgr.RunQueryStreaming(ctx, project, sqlText,
+		func(columns []string) {
+			a.results.SetColumns(columns)
+		},
+		func(rows [][]string) {
+			a.results.AppendRows(rows)
+		},
+	)
 	dur := time.Since(start)
 
 	if err != nil {
 		a.results.SetStatus(fmt.Sprintf("Error: %v", err))
-		_ = a.store.AddHistory(sqlText, project, dur, 0, err.Error())
-		a.refreshHistory()
-		a.refreshRecentProjects()
+		go func() {
+			_ = a.store.AddHistory(sqlText, project, dur, 0, err.Error())
+			a.refreshHistory()
+			a.refreshRecentProjects()
+		}()
 		return
 	}
 
-	a.results.SetData(result.Columns, result.Rows)
 	a.results.SetStatus(fmt.Sprintf("%d rows | %s | %.2f MB processed",
 		result.RowCount,
 		result.Duration.Round(time.Millisecond),
 		float64(result.BytesProcessed)/(1024*1024),
 	))
 
-	_ = a.store.AddHistory(sqlText, project, dur, result.RowCount, "")
-	a.refreshHistory()
-	a.refreshRecentProjects()
+	// Everything else in the background: history, recent projects, autocomplete context.
+	go func() {
+		_ = a.store.AddHistory(sqlText, project, dur, result.RowCount, "")
+		a.refreshHistory()
+		a.refreshRecentProjects()
+		a.updateQueryContext(sqlText)
+	}()
 }
 
 func (a *App) refreshHistory() {
@@ -596,6 +620,119 @@ func (a *App) loadProjectDataForAutocomplete(project string) {
 	wg.Wait()
 	a.explorer.CacheProjectData(project, result)
 	a.updateCompletions()
+}
+
+// cancelPendingContextUpdate stops any pending debounced schema fetch
+// so it doesn't compete with an in-flight query.
+func (a *App) cancelPendingContextUpdate() {
+	a.contextTimerMu.Lock()
+	if a.contextTimer != nil {
+		a.contextTimer.Stop()
+		a.contextTimer = nil
+	}
+	a.contextTimerMu.Unlock()
+}
+
+// scheduleContextUpdate debounces context updates triggered by text changes.
+func (a *App) scheduleContextUpdate(sql string) {
+	a.contextTimerMu.Lock()
+	defer a.contextTimerMu.Unlock()
+	if a.contextTimer != nil {
+		a.contextTimer.Stop()
+	}
+	a.contextTimer = time.AfterFunc(500*time.Millisecond, func() {
+		a.updateQueryContext(sql)
+	})
+}
+
+// updateQueryContext parses the SQL for table references, fetches missing schemas,
+// and builds per-section column completions for context-aware autocomplete.
+func (a *App) updateQueryContext(sql string) {
+	if strings.TrimSpace(sql) == "" {
+		a.editor.SetSectionCompletions(nil)
+		return
+	}
+
+	sections := ui.ParseQuerySections(sql)
+
+	// Collect all unique table refs across all sections.
+	allRefs := make(map[string]ui.TableRef)
+	for _, sec := range sections {
+		for _, ref := range sec.Tables {
+			allRefs[ref.Key()] = ref
+		}
+	}
+
+	if len(allRefs) == 0 {
+		return
+	}
+
+	// Initialize schema cache if needed.
+	if a.tableSchemaCache == nil {
+		a.tableSchemaCache = make(map[string]*bq.TableSchema)
+	}
+
+	// Fetch schemas for uncached tables.
+	var toFetch []ui.TableRef
+	for _, ref := range allRefs {
+		if _, cached := a.tableSchemaCache[ref.Key()]; !cached {
+			toFetch = append(toFetch, ref)
+		}
+	}
+
+	if len(toFetch) > 0 {
+		log.Printf("autocomplete: fetching schemas for %d tables from query", len(toFetch))
+		sem := make(chan struct{}, 5)
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		for _, ref := range toFetch {
+			ref := ref
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				schema, err := a.bqMgr.GetTableSchema(a.ctx, ref.Project, ref.Dataset, ref.Table)
+				mu.Lock()
+				if err == nil {
+					a.tableSchemaCache[ref.Key()] = schema
+				} else {
+					log.Printf("autocomplete: failed to fetch schema for %s: %v", ref.Key(), err)
+					a.tableSchemaCache[ref.Key()] = nil
+				}
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+	}
+
+	// Build section completions from sections + cached schemas.
+	scs := make([]ui.SectionCompletion, len(sections))
+	for i, sec := range sections {
+		seen := make(map[string]bool)
+		var columns []string
+		for _, ref := range sec.Tables {
+			schema := a.tableSchemaCache[ref.Key()]
+			if schema == nil {
+				continue
+			}
+			for _, f := range schema.Fields {
+				upper := strings.ToUpper(f.Name)
+				if !seen[upper] {
+					seen[upper] = true
+					columns = append(columns, f.Name)
+				}
+			}
+		}
+		sort.Strings(columns)
+		scs[i] = ui.SectionCompletion{
+			Start:   sec.Start,
+			End:     sec.End,
+			Columns: columns,
+		}
+	}
+
+	a.editor.SetSectionCompletions(scs)
 }
 
 func (a *App) handleAIMessage(userMsg string) {

--- a/bq/client.go
+++ b/bq/client.go
@@ -189,56 +189,110 @@ func (c *Client) GetTableSchema(ctx context.Context, projectID, datasetID, table
 }
 
 func (c *Client) RunQuery(ctx context.Context, projectID, sqlText string) (*QueryResult, error) {
-	cl, err := c.getClient(projectID)
+	result := &QueryResult{}
+	err := c.runQueryInternal(ctx, projectID, sqlText, result, nil, nil)
+	return result, err
+}
+
+// StreamingResult contains query metadata returned by RunQueryStreaming.
+type StreamingResult struct {
+	Columns        []string
+	Duration       time.Duration
+	BytesProcessed int64
+	RowCount       int64
+}
+
+// RunQueryStreaming executes a query and delivers results incrementally.
+// onColumns is called once the schema is known (before any rows).
+// onBatch is called with each batch of rows as they arrive from BigQuery.
+func (c *Client) RunQueryStreaming(ctx context.Context, projectID, sqlText string,
+	onColumns func(columns []string),
+	onBatch func(rows [][]string),
+) (*StreamingResult, error) {
+	sr := &StreamingResult{}
+	qr := &QueryResult{}
+	err := c.runQueryInternal(ctx, projectID, sqlText, qr, onColumns, onBatch)
 	if err != nil {
 		return nil, err
+	}
+	sr.Columns = qr.Columns
+	sr.Duration = qr.Duration
+	sr.BytesProcessed = qr.BytesProcessed
+	sr.RowCount = qr.RowCount
+	return sr, nil
+}
+
+// runQueryInternal is the shared implementation for RunQuery and RunQueryStreaming.
+// When onColumns/onBatch are nil, rows are collected into qr.Rows (batch mode).
+// When non-nil, rows are delivered via callbacks (streaming mode).
+func (c *Client) runQueryInternal(ctx context.Context, projectID, sqlText string,
+	qr *QueryResult,
+	onColumns func([]string),
+	onBatch func([][]string),
+) error {
+	cl, err := c.getClient(projectID)
+	if err != nil {
+		return err
 	}
 
 	start := time.Now()
 	q := cl.Query(sqlText)
 	job, err := q.Run(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("run query: %w", err)
+		return fmt.Errorf("run query: %w", err)
 	}
 
 	status, err := job.Wait(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("wait query: %w", err)
+		return fmt.Errorf("wait query: %w", err)
 	}
 	if status.Err() != nil {
-		return nil, fmt.Errorf("query error: %w", status.Err())
+		return fmt.Errorf("query error: %w", status.Err())
 	}
 
-	dur := time.Since(start)
+	qr.Duration = time.Since(start)
 
 	it, err := job.Read(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("read results: %w", err)
+		return fmt.Errorf("read results: %w", err)
 	}
 
-	result := &QueryResult{
-		Duration: dur,
-	}
 	if status.Statistics != nil {
-		result.BytesProcessed = status.Statistics.TotalBytesProcessed
+		qr.BytesProcessed = status.Statistics.TotalBytesProcessed
 	}
 
-	// Extract column names from schema
+	// Extract column names from schema.
 	if it.Schema != nil {
 		for _, f := range it.Schema {
-			result.Columns = append(result.Columns, f.Name)
+			qr.Columns = append(qr.Columns, f.Name)
 		}
 	}
 
-	// Read rows
-	for result.RowCount < maxRows {
+	// Deliver columns immediately so the UI can show headers.
+	if onColumns != nil {
+		onColumns(qr.Columns)
+	}
+
+	// Read rows.
+	const streamBatchSize = 100
+	var batch [][]string
+	if onBatch != nil {
+		batch = make([][]string, 0, streamBatchSize)
+	}
+	firstRow := true
+
+	for qr.RowCount < int64(maxRows) {
 		var row []bigquery.Value
 		err := it.Next(&row)
 		if err == iterator.Done {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read row: %w", err)
+			// Flush any pending batch before returning the error.
+			if onBatch != nil && len(batch) > 0 {
+				onBatch(batch)
+			}
+			return fmt.Errorf("read row: %w", err)
 		}
 		strRow := make([]string, len(row))
 		for i, v := range row {
@@ -248,9 +302,25 @@ func (c *Client) RunQuery(ctx context.Context, projectID, sqlText string) (*Quer
 				strRow[i] = fmt.Sprintf("%v", v)
 			}
 		}
-		result.Rows = append(result.Rows, strRow)
-		result.RowCount++
+		qr.RowCount++
+
+		if onBatch != nil {
+			batch = append(batch, strRow)
+			// Flush immediately on first row for instant feedback, then in batches.
+			if firstRow || len(batch) >= streamBatchSize {
+				onBatch(batch)
+				batch = make([][]string, 0, streamBatchSize)
+				firstRow = false
+			}
+		} else {
+			qr.Rows = append(qr.Rows, strRow)
+		}
 	}
 
-	return result, nil
+	// Flush remaining rows.
+	if onBatch != nil && len(batch) > 0 {
+		onBatch(batch)
+	}
+
+	return nil
 }

--- a/ui/editor.go
+++ b/ui/editor.go
@@ -28,6 +28,7 @@ type Editor struct {
 	tabData         map[*container.TabItem]*queryTab
 	tabCount        int
 	onProjectNeeded func(project string)
+	onTextChanged   func(string)
 
 	RunQuery RunQueryFunc
 	OnStop   func()
@@ -67,6 +68,17 @@ func NewEditor() *Editor {
 	e.tabs.CreateTab = func() *container.TabItem {
 		return e.newTab()
 	}
+	e.tabs.OnSelected = func(tab *container.TabItem) {
+		// Re-trigger text changed callback so context-aware completions
+		// update when switching tabs.
+		e.mu.Lock()
+		fn := e.onTextChanged
+		qt, ok := e.tabData[tab]
+		e.mu.Unlock()
+		if fn != nil && ok {
+			fn(qt.editor.Text())
+		}
+	}
 
 	// Start with one tab
 	first := e.newTab()
@@ -88,6 +100,9 @@ func (e *Editor) newTab() *container.TabItem {
 
 	e.mu.Lock()
 	editor.OnProjectNeeded = e.onProjectNeeded
+	if e.onTextChanged != nil {
+		editor.SetOnChanged(e.onTextChanged)
+	}
 	editor.OnSubmit = func() { e.run() }
 	e.tabData[tab] = &queryTab{
 		editor:  editor,
@@ -195,5 +210,27 @@ func (e *Editor) SetProjectData(data map[string]map[string][]string) {
 	e.mu.Unlock()
 	if ok {
 		qt.editor.SetProjectData(data)
+	}
+}
+
+// SetOnTextChanged sets a callback invoked when the editor text changes.
+// The callback is wired to all existing and future tabs.
+func (e *Editor) SetOnTextChanged(fn func(string)) {
+	e.mu.Lock()
+	e.onTextChanged = fn
+	for _, qt := range e.tabData {
+		qt.editor.SetOnChanged(fn)
+	}
+	e.mu.Unlock()
+}
+
+// SetSectionCompletions passes per-section column completions to the current tab's SQLEditor.
+func (e *Editor) SetSectionCompletions(sections []SectionCompletion) {
+	e.mu.Lock()
+	tab := e.tabs.Selected()
+	qt, ok := e.tabData[tab]
+	e.mu.Unlock()
+	if ok {
+		qt.editor.SetSectionCompletions(sections)
 	}
 }

--- a/ui/results.go
+++ b/ui/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image/color"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -31,6 +32,10 @@ type Results struct {
 	columns       []string
 	rows          [][]string
 	colCharLimits []int // per-column display char limit based on column width
+
+	// Double-click detection for cell copy.
+	lastTapCell widget.TableCellID
+	lastTapTime time.Time
 
 	Container fyne.CanvasObject
 }
@@ -98,6 +103,27 @@ func NewResults() *Results {
 			txt.Text = ""
 		}
 		txt.Refresh()
+	}
+
+	r.table.OnSelected = func(id widget.TableCellID) {
+		now := time.Now()
+		if id == r.lastTapCell && now.Sub(r.lastTapTime) < 400*time.Millisecond {
+			// Double-tap: copy the full cell value to clipboard.
+			if id.Row < len(r.rows) && id.Col < len(r.rows[id.Row]) {
+				val := r.rows[id.Row][id.Col]
+				if cb := fyne.CurrentApp().Clipboard(); cb != nil {
+					cb.SetContent(val)
+				}
+				col := ""
+				if id.Col < len(r.columns) {
+					col = r.columns[id.Col]
+				}
+				r.statusBar.SetText(fmt.Sprintf("Copied %s (row %d) to clipboard", col, id.Row+1))
+			}
+		}
+		r.lastTapCell = id
+		r.lastTapTime = now
+		r.table.UnselectAll()
 	}
 
 	bottomBar := container.NewHBox(r.statusBar, layout.NewSpacer(), r.copyBtn)

--- a/ui/results.go
+++ b/ui/results.go
@@ -16,13 +16,21 @@ import (
 // maxCopySize is the maximum JSON size (in bytes) allowed for clipboard copy.
 const maxCopySize = 1 << 20 // 1 MB
 
+// maxCellDisplayLen is an absolute safety cap on cell text length.
+const maxCellDisplayLen = 500
+
+// maxMeasureLen caps text length for column-width measurement.
+// Strings longer than this get maxWidth without expensive MeasureText calls.
+const maxMeasureLen = 200
+
 type Results struct {
 	table     *widget.Table
 	statusBar *widget.Label
 	copyBtn   *widget.Button
 
-	columns []string
-	rows    [][]string
+	columns       []string
+	rows          [][]string
+	colCharLimits []int // per-column display char limit based on column width
 
 	Container fyne.CanvasObject
 }
@@ -54,7 +62,16 @@ func NewResults() *Results {
 			txt.TextSize = theme.Size(theme.SizeNameText)
 			txt.Color = theme.Color(theme.ColorNameForeground)
 			if id.Row < len(r.rows) && id.Col < len(r.rows[id.Row]) {
-				txt.Text = r.rows[id.Row][id.Col]
+				val := r.rows[id.Row][id.Col]
+				// Truncate to the column's character limit so text doesn't overflow.
+				limit := maxCellDisplayLen
+				if id.Col < len(r.colCharLimits) && r.colCharLimits[id.Col] < limit {
+					limit = r.colCharLimits[id.Col]
+				}
+				if len(val) > limit {
+					val = val[:limit] + "…"
+				}
+				txt.Text = val
 			} else {
 				txt.Text = ""
 			}
@@ -91,48 +108,111 @@ func NewResults() *Results {
 func (r *Results) SetData(columns []string, rows [][]string) {
 	r.columns = columns
 	r.rows = rows
+	widths := r.computeColumnWidths()
+	fyne.Do(func() {
+		for i, w := range widths {
+			r.table.SetColumnWidth(i, w)
+		}
+		r.table.Refresh()
+		r.copyBtn.Enable()
+	})
+}
 
-	// Measure column widths based on content.
+// SetColumns sets the column headers and clears any previous rows.
+// Call this before streaming rows via AppendRows.
+func (r *Results) SetColumns(columns []string) {
+	r.columns = columns
+	r.rows = nil
+	r.colCharLimits = nil
+	fyne.Do(func() {
+		r.table.Refresh()
+		r.copyBtn.Disable()
+	})
+}
+
+// AppendRows adds rows incrementally and refreshes the table.
+// On the first batch, column widths are measured from the data.
+func (r *Results) AppendRows(newRows [][]string) {
+	firstBatch := len(r.rows) == 0
+	r.rows = append(r.rows, newRows...)
+
+	if firstBatch {
+		widths := r.computeColumnWidths()
+		fyne.Do(func() {
+			for i, w := range widths {
+				r.table.SetColumnWidth(i, w)
+			}
+			r.table.Refresh()
+			r.copyBtn.Enable()
+		})
+	} else {
+		fyne.Do(func() {
+			r.table.Refresh()
+		})
+	}
+}
+
+// computeColumnWidths measures column widths from headers and sampled rows.
+// Also computes per-column character limits for display truncation.
+func (r *Results) computeColumnWidths() []float32 {
 	textSize := fyne.CurrentApp().Settings().Theme().Size("text")
 	boldStyle := fyne.TextStyle{Bold: true}
 	normalStyle := fyne.TextStyle{}
 	const padding float32 = 24
 	const minWidth float32 = 80
 	const maxWidth float32 = 400
-	// Sample up to 100 rows to keep it fast.
-	sampleRows := len(rows)
+	sampleRows := len(r.rows)
 	if sampleRows > 100 {
 		sampleRows = 100
 	}
 
-	widths := make([]float32, len(columns))
-	for i, col := range columns {
+	widths := make([]float32, len(r.columns))
+	for i, col := range r.columns {
 		w := fyne.MeasureText(col, textSize, boldStyle).Width + padding
 		widths[i] = w
 	}
 
 	for j := 0; j < sampleRows; j++ {
-		for i := 0; i < len(columns) && i < len(rows[j]); i++ {
-			w := fyne.MeasureText(rows[j][i], textSize, normalStyle).Width + padding
+		for i := 0; i < len(r.columns) && i < len(r.rows[j]); i++ {
+			if widths[i] >= maxWidth {
+				continue
+			}
+			val := r.rows[j][i]
+			if len(val) > maxMeasureLen {
+				widths[i] = maxWidth
+				continue
+			}
+			w := fyne.MeasureText(val, textSize, normalStyle).Width + padding
 			if w > widths[i] {
 				widths[i] = w
 			}
 		}
 	}
 
-	fyne.Do(func() {
-		for i, w := range widths {
-			if w < minWidth {
-				w = minWidth
-			}
-			if w > maxWidth {
-				w = maxWidth
-			}
-			r.table.SetColumnWidth(i, w)
+	for i := range widths {
+		if widths[i] < minWidth {
+			widths[i] = minWidth
 		}
-		r.table.Refresh()
-		r.copyBtn.Enable()
-	})
+		if widths[i] > maxWidth {
+			widths[i] = maxWidth
+		}
+	}
+
+	// Compute per-column character limits from final widths.
+	charW := fyne.MeasureText("M", textSize, normalStyle).Width
+	if charW < 1 {
+		charW = 8
+	}
+	r.colCharLimits = make([]int, len(widths))
+	for i, w := range widths {
+		chars := int(w/charW) + 2 // small buffer for proportional fonts
+		if chars < 10 {
+			chars = 10
+		}
+		r.colCharLimits[i] = chars
+	}
+
+	return widths
 }
 
 func (r *Results) SetStatus(text string) {
@@ -144,6 +224,7 @@ func (r *Results) SetStatus(text string) {
 func (r *Results) Clear() {
 	r.columns = nil
 	r.rows = nil
+	r.colCharLimits = nil
 	fyne.Do(func() {
 		r.table.Refresh()
 		r.statusBar.SetText("Ready")

--- a/ui/sql_editor.go
+++ b/ui/sql_editor.go
@@ -52,14 +52,15 @@ type SQLEditor struct {
 	stopBlink   chan struct{}
 
 	// Autocomplete state.
-	completions     []string                       // full list: SQL keywords + column names
-	acProjectData   map[string]map[string][]string // project -> dataset -> []tables
-	acPrefix        string                         // prefix used for current filtering (for accept)
-	acFiltered      []string                       // filtered by current prefix
-	acVisible       bool
-	acSelected      int
-	acLoadRequested map[string]bool      // projects we've already requested loading for
-	OnProjectNeeded func(project string) // callback: request loading data for a project
+	completions        []string                       // full list: SQL keywords + column names
+	acProjectData      map[string]map[string][]string // project -> dataset -> []tables
+	acPrefix           string                         // prefix used for current filtering (for accept)
+	acFiltered         []string                       // filtered by current prefix
+	acVisible          bool
+	acSelected         int
+	acLoadRequested    map[string]bool      // projects we've already requested loading for
+	OnProjectNeeded    func(project string) // callback: request loading data for a project
+	sectionCompletions []SectionCompletion  // per-section column completions from query parsing
 
 	// AC rendering (canvas primitives, created in CreateRenderer).
 	acBg         *canvas.Rectangle
@@ -1220,6 +1221,15 @@ func (e *SQLEditor) SetProjectData(data map[string]map[string][]string) {
 	e.updateAutocomplete()
 }
 
+// SetSectionCompletions stores per-section column completions derived from query parsing.
+// Each section maps a byte-offset range to column names from tables in that section.
+func (e *SQLEditor) SetSectionCompletions(sections []SectionCompletion) {
+	e.mu.Lock()
+	e.sectionCompletions = sections
+	e.mu.Unlock()
+	e.updateAutocomplete()
+}
+
 // dottedExprBeforeCursorLocked walks left from the cursor to extract a dotted expression
 // (e.g. "project.dataset.tab"). Returns nil if no dots are found (caller should use flat completion).
 // Caller must hold mu.
@@ -1340,6 +1350,18 @@ func (e *SQLEditor) updateAutocomplete() {
 	e.mu.Lock()
 	prefix := e.wordBeforeCursorLocked()
 	completions := e.completions
+
+	// Merge context-aware columns from the section the cursor is in.
+	if len(e.sectionCompletions) > 0 {
+		offset := CursorOffset(e.lines, e.cursorRow, e.cursorCol)
+		for _, sc := range e.sectionCompletions {
+			if offset >= sc.Start && offset <= sc.End {
+				completions = mergeCompletionLists(completions, sc.Columns)
+				break
+			}
+		}
+	}
+
 	e.acPrefix = prefix
 	e.mu.Unlock()
 

--- a/ui/sql_parser.go
+++ b/ui/sql_parser.go
@@ -1,0 +1,290 @@
+package ui
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// TableRef represents a fully-qualified BigQuery table reference.
+type TableRef struct {
+	Project string
+	Dataset string
+	Table   string
+}
+
+// Key returns the dot-separated key for the table reference.
+func (t TableRef) Key() string {
+	return t.Project + "." + t.Dataset + "." + t.Table
+}
+
+// QuerySection represents a section of a SQL query (CTE body or main query).
+type QuerySection struct {
+	Start  int        // byte offset in full SQL
+	End    int        // byte offset in full SQL
+	Tables []TableRef // real table references in this section
+}
+
+// SectionCompletion maps a text range to its available column completions.
+type SectionCompletion struct {
+	Start   int
+	End     int
+	Columns []string
+}
+
+// afterFromJoinRe matches the first identifier expression after FROM or JOIN keywords.
+// Captures dotted identifiers that may include backticks (e.g. `project`.`dataset`.`table`).
+var afterFromJoinRe = regexp.MustCompile(`(?i)\b(?:FROM|JOIN)\s+([^\s,()]+)`)
+
+// ExtractTableRefs finds all fully-qualified table references (project.dataset.table) in SQL.
+func ExtractTableRefs(sql string) []TableRef {
+	matches := afterFromJoinRe.FindAllStringSubmatch(sql, -1)
+	seen := make(map[string]bool)
+	var refs []TableRef
+	for _, m := range matches {
+		ref := strings.ReplaceAll(m[1], "`", "")
+		parts := strings.Split(ref, ".")
+		if len(parts) != 3 {
+			continue
+		}
+		key := parts[0] + "." + parts[1] + "." + parts[2]
+		if !seen[key] {
+			seen[key] = true
+			refs = append(refs, TableRef{Project: parts[0], Dataset: parts[1], Table: parts[2]})
+		}
+	}
+	return refs
+}
+
+// ParseQuerySections splits SQL into sections (CTE bodies and main query),
+// each with their table references. CTE bodies only get refs from their own body.
+// The main query section gets ALL table refs from the entire query.
+func ParseQuerySections(sql string) []QuerySection {
+	if strings.TrimSpace(sql) == "" {
+		return nil
+	}
+
+	trimmed := strings.TrimLeft(sql, " \t\n\r")
+
+	// Check for WITH keyword
+	if len(trimmed) < 4 || !strings.EqualFold(trimmed[:4], "WITH") {
+		refs := ExtractTableRefs(sql)
+		return []QuerySection{{Start: 0, End: len(sql), Tables: refs}}
+	}
+
+	// Check that WITH is followed by a word boundary (not part of another keyword)
+	withOffset := len(sql) - len(trimmed)
+	afterWith := withOffset + 4
+	if afterWith < len(sql) && isAlpha(sql[afterWith]) {
+		// "WITH" is part of a longer word, not a CTE keyword
+		refs := ExtractTableRefs(sql)
+		return []QuerySection{{Start: 0, End: len(sql), Tables: refs}}
+	}
+
+	var sections []QuerySection
+	pos := afterWith
+
+	// Skip optional RECURSIVE keyword
+	rest := strings.TrimLeft(sql[pos:], " \t\n\r")
+	if len(rest) >= 9 && strings.EqualFold(rest[:9], "RECURSIVE") {
+		afterRecursive := len(sql) - len(rest) + 9
+		if afterRecursive >= len(sql) || !isAlpha(sql[afterRecursive]) {
+			pos = afterRecursive
+		}
+	}
+
+	asParenRe := regexp.MustCompile(`(?i)\bAS\s*\(`)
+
+	for pos < len(sql) {
+		remaining := sql[pos:]
+		loc := asParenRe.FindStringIndex(remaining)
+		if loc == nil {
+			break
+		}
+
+		// Find the '(' in the match
+		openParen := -1
+		for i := pos + loc[0]; i < pos+loc[1]; i++ {
+			if sql[i] == '(' {
+				openParen = i
+				break
+			}
+		}
+		if openParen < 0 {
+			break
+		}
+
+		closeParen := findMatchingParen(sql, openParen)
+		if closeParen < 0 {
+			break
+		}
+
+		bodyStart := openParen + 1
+		bodyEnd := closeParen
+		body := sql[bodyStart:bodyEnd]
+		refs := ExtractTableRefs(body)
+
+		sections = append(sections, QuerySection{
+			Start:  bodyStart,
+			End:    bodyEnd,
+			Tables: refs,
+		})
+
+		// Move past the closing paren
+		pos = closeParen + 1
+
+		// Skip comma and whitespace
+		for pos < len(sql) && (sql[pos] == ',' || unicode.IsSpace(rune(sql[pos]))) {
+			pos++
+		}
+
+		// Check if next token is a main query keyword
+		nextWord := nextSQLKeyword(sql[pos:])
+		if isMainQueryKeyword(nextWord) {
+			break
+		}
+	}
+
+	// Main query section: from pos to end, with ALL table refs from entire query
+	if pos < len(sql) {
+		allRefs := ExtractTableRefs(sql)
+		sections = append(sections, QuerySection{
+			Start:  pos,
+			End:    len(sql),
+			Tables: allRefs,
+		})
+	}
+
+	return sections
+}
+
+// CursorOffset converts (row, col) to byte offset in multi-line text joined by newlines.
+func CursorOffset(lines []string, row, col int) int {
+	offset := 0
+	for i := 0; i < row && i < len(lines); i++ {
+		offset += len(lines[i]) + 1 // +1 for \n
+	}
+	if row < len(lines) {
+		if col > len(lines[row]) {
+			col = len(lines[row])
+		}
+		offset += col
+	}
+	return offset
+}
+
+// findMatchingParen finds the closing ')' matching the '(' at openPos.
+// Returns -1 if no match is found. Handles string literals, quoted identifiers, and comments.
+func findMatchingParen(sql string, openPos int) int {
+	if openPos >= len(sql) || sql[openPos] != '(' {
+		return -1
+	}
+	depth := 1
+	i := openPos + 1
+	for i < len(sql) && depth > 0 {
+		switch sql[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		case '\'':
+			// Skip single-quoted string literal
+			i++
+			for i < len(sql) {
+				if sql[i] == '\'' {
+					if i+1 < len(sql) && sql[i+1] == '\'' {
+						i += 2 // escaped quote
+						continue
+					}
+					break
+				}
+				i++
+			}
+		case '"':
+			// Skip double-quoted identifier
+			i++
+			for i < len(sql) && sql[i] != '"' {
+				i++
+			}
+		case '`':
+			// Skip backtick-quoted identifier
+			i++
+			for i < len(sql) && sql[i] != '`' {
+				i++
+			}
+		case '-':
+			// Check for -- line comment
+			if i+1 < len(sql) && sql[i+1] == '-' {
+				for i < len(sql) && sql[i] != '\n' {
+					i++
+				}
+				continue // don't increment again
+			}
+		case '/':
+			// Check for /* block comment */
+			if i+1 < len(sql) && sql[i+1] == '*' {
+				i += 2
+				for i+1 < len(sql) {
+					if sql[i] == '*' && sql[i+1] == '/' {
+						i++ // skip past '/'
+						break
+					}
+					i++
+				}
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// mergeCompletionLists merges two sorted completion lists, deduplicating case-insensitively.
+func mergeCompletionLists(base, extra []string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[string]bool, len(base))
+	for _, s := range base {
+		seen[strings.ToUpper(s)] = true
+	}
+	var newItems []string
+	for _, s := range extra {
+		if !seen[strings.ToUpper(s)] {
+			seen[strings.ToUpper(s)] = true
+			newItems = append(newItems, s)
+		}
+	}
+	if len(newItems) == 0 {
+		return base
+	}
+	merged := make([]string, 0, len(base)+len(newItems))
+	merged = append(merged, base...)
+	merged = append(merged, newItems...)
+	sort.Strings(merged)
+	return merged
+}
+
+func nextSQLKeyword(sql string) string {
+	s := strings.TrimLeft(sql, " \t\n\r")
+	end := 0
+	for end < len(s) && isAlpha(s[end]) {
+		end++
+	}
+	return s[:end]
+}
+
+func isMainQueryKeyword(word string) bool {
+	switch strings.ToUpper(word) {
+	case "SELECT", "INSERT", "UPDATE", "DELETE", "MERGE", "CREATE", "DROP", "ALTER":
+		return true
+	}
+	return false
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_'
+}

--- a/ui/sql_parser_test.go
+++ b/ui/sql_parser_test.go
@@ -1,0 +1,432 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+)
+
+// --- ExtractTableRefs tests ---
+
+func TestExtractTableRefs_Simple(t *testing.T) {
+	sql := "SELECT * FROM my-project.dataset.orders"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Project != "my-project" || refs[0].Dataset != "dataset" || refs[0].Table != "orders" {
+		t.Errorf("unexpected ref: %+v", refs[0])
+	}
+}
+
+func TestExtractTableRefs_BacktickQuotedFull(t *testing.T) {
+	sql := "SELECT * FROM `my-project.dataset.orders`"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Key() != "my-project.dataset.orders" {
+		t.Errorf("unexpected key: %s", refs[0].Key())
+	}
+}
+
+func TestExtractTableRefs_BacktickPerComponent(t *testing.T) {
+	sql := "SELECT * FROM `my-project`.`dataset`.`orders`"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Key() != "my-project.dataset.orders" {
+		t.Errorf("unexpected key: %s", refs[0].Key())
+	}
+}
+
+func TestExtractTableRefs_MultipleJoins(t *testing.T) {
+	sql := `SELECT *
+FROM project.ds.table_a a
+JOIN project.ds.table_b b ON a.id = b.id
+LEFT JOIN project.ds.table_c c ON a.id = c.id`
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 3 {
+		t.Fatalf("expected 3 refs, got %d: %+v", len(refs), refs)
+	}
+	keys := make([]string, len(refs))
+	for i, r := range refs {
+		keys[i] = r.Key()
+	}
+	expected := []string{
+		"project.ds.table_a",
+		"project.ds.table_b",
+		"project.ds.table_c",
+	}
+	if !reflect.DeepEqual(keys, expected) {
+		t.Errorf("expected %v, got %v", expected, keys)
+	}
+}
+
+func TestExtractTableRefs_TwoPartIgnored(t *testing.T) {
+	sql := "SELECT * FROM dataset.table_name"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 0 {
+		t.Errorf("expected 0 refs for 2-part reference, got %d: %+v", len(refs), refs)
+	}
+}
+
+func TestExtractTableRefs_Subquery(t *testing.T) {
+	sql := "SELECT * FROM (SELECT * FROM project.ds.inner_table) sub"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Key() != "project.ds.inner_table" {
+		t.Errorf("unexpected key: %s", refs[0].Key())
+	}
+}
+
+func TestExtractTableRefs_NoMatch(t *testing.T) {
+	sql := "SELECT 1 + 2"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 0 {
+		t.Errorf("expected 0 refs, got %d", len(refs))
+	}
+}
+
+func TestExtractTableRefs_Deduplicates(t *testing.T) {
+	sql := `SELECT * FROM project.ds.t1
+UNION ALL
+SELECT * FROM project.ds.t1`
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Errorf("expected 1 ref (deduped), got %d", len(refs))
+	}
+}
+
+func TestExtractTableRefs_CaseInsensitiveKeywords(t *testing.T) {
+	sql := "select * from project.ds.orders"
+	refs := ExtractTableRefs(sql)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Key() != "project.ds.orders" {
+		t.Errorf("unexpected key: %s", refs[0].Key())
+	}
+}
+
+// --- ParseQuerySections tests ---
+
+func TestParseQuerySections_NoCTEs(t *testing.T) {
+	sql := "SELECT * FROM project.ds.orders WHERE id = 1"
+	sections := ParseQuerySections(sql)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if sections[0].Start != 0 || sections[0].End != len(sql) {
+		t.Errorf("unexpected section bounds: [%d, %d]", sections[0].Start, sections[0].End)
+	}
+	if len(sections[0].Tables) != 1 {
+		t.Errorf("expected 1 table ref, got %d", len(sections[0].Tables))
+	}
+}
+
+func TestParseQuerySections_SingleCTE(t *testing.T) {
+	sql := `WITH cte AS (
+  SELECT * FROM project.ds.orders
+)
+SELECT * FROM cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections (1 CTE + main), got %d", len(sections))
+	}
+
+	// CTE section should have the orders table
+	cte := sections[0]
+	if len(cte.Tables) != 1 || cte.Tables[0].Table != "orders" {
+		t.Errorf("CTE section: expected 1 ref to 'orders', got %+v", cte.Tables)
+	}
+
+	// Main section should have all refs (orders from the whole query)
+	main := sections[1]
+	if len(main.Tables) != 1 || main.Tables[0].Table != "orders" {
+		t.Errorf("main section: expected 1 ref to 'orders', got %+v", main.Tables)
+	}
+}
+
+func TestParseQuerySections_MultipleCTEs(t *testing.T) {
+	sql := `WITH
+  first_cte AS (
+    SELECT * FROM project.ds.table_a
+  ),
+  second_cte AS (
+    SELECT * FROM project.ds.table_b
+  )
+SELECT * FROM first_cte JOIN second_cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 3 {
+		t.Fatalf("expected 3 sections (2 CTEs + main), got %d", len(sections))
+	}
+
+	// First CTE: only table_a
+	if len(sections[0].Tables) != 1 || sections[0].Tables[0].Table != "table_a" {
+		t.Errorf("first CTE: expected table_a, got %+v", sections[0].Tables)
+	}
+
+	// Second CTE: only table_b
+	if len(sections[1].Tables) != 1 || sections[1].Tables[0].Table != "table_b" {
+		t.Errorf("second CTE: expected table_b, got %+v", sections[1].Tables)
+	}
+
+	// Main query: all table refs from entire query (table_a + table_b)
+	if len(sections[2].Tables) != 2 {
+		t.Errorf("main section: expected 2 refs, got %d: %+v", len(sections[2].Tables), sections[2].Tables)
+	}
+}
+
+func TestParseQuerySections_NestedParens(t *testing.T) {
+	sql := `WITH cte AS (
+  SELECT * FROM project.ds.orders
+  WHERE id IN (SELECT id FROM project.ds.filter)
+)
+SELECT * FROM cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+
+	// CTE body should contain both table refs
+	cte := sections[0]
+	if len(cte.Tables) != 2 {
+		t.Errorf("CTE section: expected 2 refs, got %d: %+v", len(cte.Tables), cte.Tables)
+	}
+}
+
+func TestParseQuerySections_StringWithParens(t *testing.T) {
+	sql := `WITH cte AS (
+  SELECT * FROM project.ds.orders
+  WHERE name = '(not a paren)'
+)
+SELECT * FROM cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+
+	cte := sections[0]
+	if len(cte.Tables) != 1 || cte.Tables[0].Table != "orders" {
+		t.Errorf("CTE section: expected 1 ref to 'orders', got %+v", cte.Tables)
+	}
+}
+
+func TestParseQuerySections_EmptySQL(t *testing.T) {
+	sections := ParseQuerySections("")
+	if len(sections) != 0 {
+		t.Errorf("expected 0 sections for empty SQL, got %d", len(sections))
+	}
+
+	sections = ParseQuerySections("   ")
+	if len(sections) != 0 {
+		t.Errorf("expected 0 sections for whitespace SQL, got %d", len(sections))
+	}
+}
+
+func TestParseQuerySections_CursorInCTEBody(t *testing.T) {
+	sql := `WITH
+  first_cte AS (
+    SELECT * FROM project.ds.table_a
+  ),
+  second_cte AS (
+    SELECT * FROM project.ds.table_b
+  )
+SELECT * FROM first_cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(sections))
+	}
+
+	// Verify section boundaries don't overlap
+	for i := 0; i < len(sections)-1; i++ {
+		if sections[i].End > sections[i+1].Start {
+			t.Errorf("sections %d and %d overlap: [%d,%d] and [%d,%d]",
+				i, i+1, sections[i].Start, sections[i].End, sections[i+1].Start, sections[i+1].End)
+		}
+	}
+
+	// First CTE should only have table_a
+	if len(sections[0].Tables) != 1 || sections[0].Tables[0].Table != "table_a" {
+		t.Errorf("first CTE tables: %+v", sections[0].Tables)
+	}
+
+	// Second CTE should only have table_b
+	if len(sections[1].Tables) != 1 || sections[1].Tables[0].Table != "table_b" {
+		t.Errorf("second CTE tables: %+v", sections[1].Tables)
+	}
+}
+
+func TestParseQuerySections_CommentInCTE(t *testing.T) {
+	sql := `WITH cte AS (
+  -- This is a comment with ) in it
+  SELECT * FROM project.ds.orders
+)
+SELECT * FROM cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if len(sections[0].Tables) != 1 {
+		t.Errorf("expected 1 table ref in CTE, got %d", len(sections[0].Tables))
+	}
+}
+
+func TestParseQuerySections_BlockCommentInCTE(t *testing.T) {
+	sql := `WITH cte AS (
+  /* block comment with ) paren */
+  SELECT * FROM project.ds.orders
+)
+SELECT * FROM cte`
+
+	sections := ParseQuerySections(sql)
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if len(sections[0].Tables) != 1 {
+		t.Errorf("expected 1 table ref in CTE, got %d", len(sections[0].Tables))
+	}
+}
+
+// --- CursorOffset tests ---
+
+func TestCursorOffset_FirstLine(t *testing.T) {
+	lines := []string{"SELECT *", "FROM table"}
+	offset := CursorOffset(lines, 0, 4)
+	if offset != 4 {
+		t.Errorf("expected 4, got %d", offset)
+	}
+}
+
+func TestCursorOffset_SecondLine(t *testing.T) {
+	lines := []string{"SELECT *", "FROM table"}
+	// Line 0 is "SELECT *" (8 chars) + 1 newline = 9
+	// Col 5 on line 1 = 14
+	offset := CursorOffset(lines, 1, 5)
+	if offset != 14 {
+		t.Errorf("expected 14, got %d", offset)
+	}
+}
+
+func TestCursorOffset_StartOfFile(t *testing.T) {
+	lines := []string{"hello"}
+	offset := CursorOffset(lines, 0, 0)
+	if offset != 0 {
+		t.Errorf("expected 0, got %d", offset)
+	}
+}
+
+func TestCursorOffset_EndOfFile(t *testing.T) {
+	lines := []string{"abc", "def"}
+	// "abc\ndef" → offset of end = 3+1+3 = 7
+	offset := CursorOffset(lines, 1, 3)
+	if offset != 7 {
+		t.Errorf("expected 7, got %d", offset)
+	}
+}
+
+func TestCursorOffset_ColBeyondLineLength(t *testing.T) {
+	lines := []string{"ab"}
+	offset := CursorOffset(lines, 0, 100)
+	if offset != 2 {
+		t.Errorf("expected 2 (clamped), got %d", offset)
+	}
+}
+
+// --- findMatchingParen tests ---
+
+func TestFindMatchingParen_Simple(t *testing.T) {
+	sql := "(hello)"
+	got := findMatchingParen(sql, 0)
+	if got != 6 {
+		t.Errorf("expected 6, got %d", got)
+	}
+}
+
+func TestFindMatchingParen_Nested(t *testing.T) {
+	sql := "(a(b)c)"
+	got := findMatchingParen(sql, 0)
+	if got != 6 {
+		t.Errorf("expected 6, got %d", got)
+	}
+}
+
+func TestFindMatchingParen_StringWithParen(t *testing.T) {
+	sql := "(a ')' b)"
+	got := findMatchingParen(sql, 0)
+	if got != 8 {
+		t.Errorf("expected 8, got %d", got)
+	}
+}
+
+func TestFindMatchingParen_Unmatched(t *testing.T) {
+	sql := "(abc"
+	got := findMatchingParen(sql, 0)
+	if got != -1 {
+		t.Errorf("expected -1, got %d", got)
+	}
+}
+
+func TestFindMatchingParen_LineComment(t *testing.T) {
+	sql := "(-- )\nhello)"
+	got := findMatchingParen(sql, 0)
+	if got != 11 {
+		t.Errorf("expected 11, got %d", got)
+	}
+}
+
+func TestFindMatchingParen_BlockComment(t *testing.T) {
+	sql := "(/* ) */ done)"
+	got := findMatchingParen(sql, 0)
+	if got != 13 {
+		t.Errorf("expected 13, got %d", got)
+	}
+}
+
+// --- mergeCompletionLists tests ---
+
+func TestMergeCompletionLists_Empty(t *testing.T) {
+	base := []string{"A", "B"}
+	result := mergeCompletionLists(base, nil)
+	if !reflect.DeepEqual(result, base) {
+		t.Errorf("expected base unchanged, got %v", result)
+	}
+}
+
+func TestMergeCompletionLists_NoDuplicates(t *testing.T) {
+	base := []string{"A", "C"}
+	extra := []string{"B", "D"}
+	result := mergeCompletionLists(base, extra)
+	expected := []string{"A", "B", "C", "D"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestMergeCompletionLists_CaseInsensitiveDedup(t *testing.T) {
+	base := []string{"SELECT", "from"}
+	extra := []string{"select", "new_col"}
+	result := mergeCompletionLists(base, extra)
+	// "select" should be deduped (case-insensitive match with "SELECT")
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d: %v", len(result), result)
+	}
+}
+
+// --- TableRef.Key tests ---
+
+func TestTableRef_Key(t *testing.T) {
+	ref := TableRef{Project: "proj", Dataset: "ds", Table: "tbl"}
+	if ref.Key() != "proj.ds.tbl" {
+		t.Errorf("expected 'proj.ds.tbl', got %q", ref.Key())
+	}
+}


### PR DESCRIPTION
- Autocomplete now suggests column names based on the tables in your query. Paste or type a query with fully-qualified table references, and column names become available; scoped per CTE so you only see relevant columns for the section you're editing.
- Query results now stream incrementally instead of waiting for all rows to download, which makes a big difference for tables with heavy columns like large JSON fields.
- double-click any cell to copy its full value to clipboard.